### PR TITLE
[IPX-427] Keep values in parentheses together when pressing division key

### DIFF
--- a/src/core/delimiters.ts
+++ b/src/core/delimiters.ts
@@ -54,6 +54,12 @@ export const RIGHT_DELIM = {
   '\\lmoustache': '\\rmoustache',
 };
 
+export const LEFT_DELIM =
+  Object.fromEntries(
+    Object.entries(RIGHT_DELIM)
+      .map(([leftDelim, rightDelim]) => [rightDelim, leftDelim])
+  );
+
 function getSymbolValue(symbol: string): number {
   return (
     {


### PR DESCRIPTION
- request update only when nested mathfields change
- remove nested mathfield when they were remove from the expression
- fix: partially fix #1087 invoke `scrollIntoView` in `performWithFeedback`
- fix: fix #1087 invoke `scrollIntoView` in `insert` commands
- chore: rollup-plugin-eslint is not compatible with prettier. Turn it off for now. Re-enable when compatible version available.
- fix: fix #1146 Do not prevent scrolling of page when cursor over mathfield
- chore: deps/lint
- 0.69.8
- feat: when using the  scrollwheel, don't capture the scroll if the field cannot be scrolled further
- chore: deps
- chore: don't attempt to reload the local server if already running
- fix: Fixed #1240
- chore: deps
- chore: deps
- fix(1195): correct parsing of subgroup elements
- fix: reverting #1270 to fix #1272
- fix: integrate PR#1271
- chore: deps
- chore: lint
- feat: vue-mathlive support vue 3.x
- fix: z-index of virtual keyboard would not apply correctly
- chore: deps
- 0.69.9
- chore: update maintenance status
- chore: remove outdated status badge
- htmlStyle support
- htmlStyle support
- Fix : roundedbox not displaying #1300
- fix: properly observe `read-only` changes
- core-definitions: fix \ne \neq rendering issue
- chore(deps): bump follow-redirects from 1.14.6 to 1.14.8
- fix: Fixed #1357. Deps update.
- 0.69.10
- Fixed: prevent virtual keyboard from closing when clicking on other parts of the kb other than the key elements
- fix: link to Contributor Guide
- fix: Fixed #1366 by removing stop propagation
- fix: exception thrown if PointerEvent doesn't exist
- chore: deps
- 0.69.11
- fix: Fixed #934 by moving translate
- feat: Add rendering test page
- fix: add appropriate gap to aligned environment
- fix: Fixed #1362 and #726 by comparing only the whole shortcut candidate and not substrings
- doc, lint
- fix: #1377 add macros in the command popover
- doc
- fix: fix #1385 Typing '&' should be escaped in LaTeX
- fix: fix #1375 Correctly handle inserting smartfence with not content after
- fix: fix #1375 continuation
- fix: fixed Unable to remove \overrightarrow{} with backspace #1363
- doc: fixed #1363
- lint
- fix: on Windows/Linuz AZERTY keyboard, the Backquote key is superscript 2...
- doc: added example for custom virtual keyboard
- fix: custom macro do not work when executeCommand insert or MathfieldElement setValue
- doc: correct references to CDN
- feat: minor optimization
- chore: fix npm/node dependency to LTS
- doc
- feat: improved dark mode appearance
- feat: use Compute Engine for parsing/serializing to MathJSON
- fix: correctly display SVG shapes in dark mode
- chore deps
- 0.70.0
- Group parenthesized args for implicitness
